### PR TITLE
Fix generate_encryption_key

### DIFF
--- a/cryptographic_fields/management/commands/generate_encryption_key.py
+++ b/cryptographic_fields/management/commands/generate_encryption_key.py
@@ -8,4 +8,5 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         key = cryptography.fernet.Fernet.generate_key()
-        self.stdout.write(key)
+        key_as_str = key.decode('utf-8')
+        self.stdout.write(key_as_str)


### PR DESCRIPTION
## Purpose
- Fix `generate_encryption_key` exception caused by writing bytes to a stdout.

## Approach
- Decode bytes to string using `utf-8` before writing to stdout.

## Screen shot
```
Traceback (most recent call last):
  File "manage.py", line 21, in <module>
    main()
  File "manage.py", line 17, in main
    execute_from_command_line(sys.argv)
  File "/usr/local/lib/python3.7/site-packages/django/core/management/__init__.py", line 401, in execute_from_command_line
    utility.execute()
  File "/usr/local/lib/python3.7/site-packages/django/core/management/__init__.py", line 395, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/usr/local/lib/python3.7/site-packages/django/core/management/base.py", line 328, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/usr/local/lib/python3.7/site-packages/django/core/management/base.py", line 369, in execute
    output = self.handle(*args, **options)
  File "/usr/local/lib/python3.7/site-packages/cryptographic_fields/management/commands/generate_encryption_key.py", line 11, in handle
    self.stdout.write(key)
  File "/usr/local/lib/python3.7/site-packages/django/core/management/base.py", line 142, in write
    if ending and not msg.endswith(ending):
TypeError: endswith first arg must be bytes or a tuple of bytes, not str
```